### PR TITLE
Implement Player Controls on Instance Difficulty

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,16 @@
-# ![logo](https://raw.githubusercontent.com/azerothcore/azerothcore.github.io/master/images/logo-github.png) AzerothCore
+## Dungeon Balance
 
-## AutoBalance
+This module is intended to scale based on number of players, instance mobs and bosses' health, mana, and damage. All settings are well-described in the configuration file.
 
-- Latest build status with azerothcore: [![Build Status](https://github.com/azerothcore/mod-autobalance/workflows/core-build/badge.svg?branch=master&event=push)](https://github.com/azerothcore/mod-autobalance)
-
-This module is intended to scale based on number of players, instance mobs and bosses' health, mana, and damage.
-
-**NOTE:** This module requires at least [this commit](https://github.com/azerothcore/azerothcore-wotlk/commit/f127e583aae3cfa51a77d056c1892a7de07ffb52) of AzerothCore in order to work correctly. Older versions are not supported.
-
-All settings are well-described in the configuration file.
-
-**PLEASE** include the output from the `.ab mapstat` and `.ab creaturestat` commands (while targeting a problematic creature) when reporting issues. This will help us to quickly identify the problem and provide a solution.
+**NOTE 1:** This module requires at least [this commit](https://github.com/azerothcore/azerothcore-wotlk/commit/f127e583aae3cfa51a77d056c1892a7de07ffb52) of AzerothCore in order to work correctly. Older versions are not supported.
+**NOTE 2:** This is customized from the source mode called "AutoBalance" found here: https://github.com/azerothcore/mod-autobalance
 
 ## In-game Commands
 | Command | Permission | Description |
 | :------ | :--------- | :---------- |
-| `.ab mapstat` | All Players | Displays AB-calcualted settings for the current map, including player count, difficulty, world modifiers, and others. |
-| `.ab creaturestat` | All Players | Displays AB-calculated settings for the targeted dungeon creature including level scaling, difficulty, modifiers, and boss status. |
-| `.ab setoffset` | Game Masters | Sets the server-wide player difficulty offset. Instances will be scaled as though they had this many more/less players than they really do. |
-| `.ab getoffset` | All Players | Gets the current server-wide player difficulty offset. Instances will be scaled as though they had this many more/less players than they really do. |
-| `.reload config` | Game Masters | Reloads all your configuration files, including `AutoBalance.conf`. This lets you update AutoBalance settings without restarting your worldserver. This module is designed to contiue to work as expected when this command is issued. |
+| `.dungeonbalance setplayers` | All Players | Sets a fixed player count difficulty for the player's current dungeon instance, which doesn't change even if players join or leave. |
+| `.dungeonbalance getmapstat` | All Players | Displays AB-calcualted settings for the current map, including player count, difficulty, world modifiers, and others. |
+| `.dungeonbalance getcreaturestat` | All Players | Displays AB-calculated settings for the targeted dungeon creature including level scaling, difficulty, modifiers, and boss status. |
 
 ## Logger Names
 | Logger | Description |

--- a/conf/AutoBalance.conf.dist
+++ b/conf/AutoBalance.conf.dist
@@ -170,14 +170,14 @@ AutoBalance.MinPlayers.Heroic.PerInstance = ""
 #     The "Final Multiplier" value is the actual multiplier that will be applied to enemies in a given dungeon.
 
 ### 5-player dungeons
-AutoBalance.InflectionPoint=0.56
-AutoBalance.InflectionPoint.CurveFloor=0.04
+AutoBalance.InflectionPoint=0.5
+AutoBalance.InflectionPoint.CurveFloor=0.0
 AutoBalance.InflectionPoint.CurveCeiling=1.0
 AutoBalance.InflectionPoint.BossModifier=1.0
 
 ### 5-player heroic dungeons
-AutoBalance.InflectionPointHeroic=0.56
-AutoBalance.InflectionPointHeroic.CurveFloor=0.04
+AutoBalance.InflectionPointHeroic=0.5
+AutoBalance.InflectionPointHeroic.CurveFloor=0.0
 AutoBalance.InflectionPointHeroic.CurveCeiling=1.0
 AutoBalance.InflectionPointHeroic.BossModifier=1.0
 
@@ -908,9 +908,11 @@ AutoBalance.RewardScaling.Money.Modifier = 1.0
 
 #
 #     AutoBalance.RewardScaling.Loot
-#        Scale Loot drop chance based on the health and damage modifiers on the creature.  If set to 0, the full
+#        Scale Loot drop chance based on the number of players in the dungeon vs the max.  If set to 0, the full
 #        chance to drop will be at play.
 #        
+#        Example: 5 man dungeon with 3 player difficulty will have 60% drop chance (3/5)
+#
 #        Quest items will always drop with no regard to this setting
 #
 #        Default: 1 (1 = ON, 0 = OFF)
@@ -919,6 +921,7 @@ AutoBalance.RewardScaling.Money.Modifier = 1.0
 #        If set to 1, BOP items will always drop (such as loot from most bosses)
 #
 #        Default: 1 (Always drop BOP items)
+#
 AutoBalance.RewardScaling.Loot = 1
 AutoBalance.RewardScaling.Loot.BOPAlwaysDropException = 1
 

--- a/conf/AutoBalance.conf.dist
+++ b/conf/AutoBalance.conf.dist
@@ -171,13 +171,13 @@ AutoBalance.MinPlayers.Heroic.PerInstance = ""
 
 ### 5-player dungeons
 AutoBalance.InflectionPoint=0.5
-AutoBalance.InflectionPoint.CurveFloor=0.1
+AutoBalance.InflectionPoint.CurveFloor=0.0
 AutoBalance.InflectionPoint.CurveCeiling=1.0
 AutoBalance.InflectionPoint.BossModifier=1.0
 
 ### 5-player heroic dungeons
 AutoBalance.InflectionPointHeroic=0.5
-AutoBalance.InflectionPointHeroic.CurveFloor=0.1
+AutoBalance.InflectionPointHeroic.CurveFloor=0.0
 AutoBalance.InflectionPointHeroic.CurveCeiling=1.0
 AutoBalance.InflectionPointHeroic.BossModifier=1.0
 
@@ -903,7 +903,7 @@ AutoBalance.RewardScaling.XP.Modifier = 1.0
 #        rewarded to each player, 1 gold 50 silver will be rewarded.
 #
 #        Default: 1.0 (no change)
-AutoBalance.RewardScaling.Money = 0
+AutoBalance.RewardScaling.Money = 1
 AutoBalance.RewardScaling.Money.Modifier = 1.0
 
 ##########################

--- a/conf/AutoBalance.conf.dist
+++ b/conf/AutoBalance.conf.dist
@@ -170,14 +170,14 @@ AutoBalance.MinPlayers.Heroic.PerInstance = ""
 #     The "Final Multiplier" value is the actual multiplier that will be applied to enemies in a given dungeon.
 
 ### 5-player dungeons
-AutoBalance.InflectionPoint=0.5
-AutoBalance.InflectionPoint.CurveFloor=0.0
+AutoBalance.InflectionPoint=0.56
+AutoBalance.InflectionPoint.CurveFloor=0.04
 AutoBalance.InflectionPoint.CurveCeiling=1.0
 AutoBalance.InflectionPoint.BossModifier=1.0
 
 ### 5-player heroic dungeons
-AutoBalance.InflectionPointHeroic=0.5
-AutoBalance.InflectionPointHeroic.CurveFloor=0.0
+AutoBalance.InflectionPointHeroic=0.56
+AutoBalance.InflectionPointHeroic.CurveFloor=0.04
 AutoBalance.InflectionPointHeroic.CurveCeiling=1.0
 AutoBalance.InflectionPointHeroic.BossModifier=1.0
 
@@ -905,6 +905,22 @@ AutoBalance.RewardScaling.XP.Modifier = 1.0
 #        Default: 1.0 (no change)
 AutoBalance.RewardScaling.Money = 1
 AutoBalance.RewardScaling.Money.Modifier = 1.0
+
+#
+#     AutoBalance.RewardScaling.Loot
+#        Scale Loot drop chance based on the health and damage modifiers on the creature.  If set to 0, the full
+#        chance to drop will be at play.
+#        
+#        Quest items will always drop with no regard to this setting
+#
+#        Default: 1 (1 = ON, 0 = OFF)
+#
+#     AutoBalance.RewardScaling.Loot.BOPAlwaysDropException
+#        If set to 1, BOP items will always drop (such as loot from most bosses)
+#
+#        Default: 1 (Always drop BOP items)
+AutoBalance.RewardScaling.Loot = 1
+AutoBalance.RewardScaling.Loot.BOPAlwaysDropException = 1
 
 ##########################
 #

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -22,7 +22,8 @@
 /*
 * Script Name: AutoBalance
 * Original Authors: KalCorp and Vaughner
-* Maintainer(s): AzerothCore
+* Original Maintainer(s): AzerothCore
+* Modifications Author/Maintainer: Nathan Handley (For Eternal Wrath)
 * Original Script Name: AutoBalance
 * Description: This script is intended to scale based on number of players,
 * instance mobs & world bosses' level, health, mana, and damage.
@@ -192,6 +193,7 @@ public:
 
     uint8 playerCount = 0;                           // the actual number of non-GM players in the map
     uint8 adjustedPlayerCount = 0;                   // the currently difficulty level expressed as number of players
+    uint8 overridePlayerCount = 0;                   // override difficulty if set
     uint8 minPlayers = 1;                            // will be set by the config
 
     uint8 mapLevel = 0;                              // calculated from the avgCreatureLevel
@@ -2597,8 +2599,11 @@ void UpdateMapPlayerStats(Map* map)
     if (adjustedPlayerCount < mapABInfo->minPlayers)
         adjustedPlayerCount = mapABInfo->minPlayers;
 
-    // adjust by the PlayerDifficultyOffset
-    adjustedPlayerCount += PlayerCountDifficultyOffset;
+    // adjust by the override, or the PlayerDifficultyOffset
+    if (mapABInfo->overridePlayerCount > 0)
+        adjustedPlayerCount = mapABInfo->overridePlayerCount;
+    else
+        adjustedPlayerCount += PlayerCountDifficultyOffset;
 
     // store the adjusted player count in the map's info
     mapABInfo->adjustedPlayerCount = adjustedPlayerCount;
@@ -3707,7 +3712,7 @@ class AutoBalance_PlayerScript : public PlayerScript
                     {
                         if (player && player->GetSession())
                         {
-                            ChatHandler(player->GetSession()).PSendSysMessage("|cffc3dbff [AutoBalance]|r|cffFF8000 Combat has ended. Difficulty is no longer locked.|r");
+                            ChatHandler(player->GetSession()).PSendSysMessage("Combat has ended. Map Difficulty is no longer locked.|r");
                         }
                     }
                 }
@@ -4638,10 +4643,7 @@ class AutoBalance_AllMapScript : public AllMapScript
 
                                 if (thisPlayer && thisPlayer == player) // This is the player that entered
                                 {
-                                    chatHandle.PSendSysMessage("|cffc3dbff [AutoBalance]|r|cffFF8000 Welcome to %s (%u-player %s). There are %u player(s) in this instance. Difficulty set to %u player(s).|r",
-                                        map->GetMapName(),
-                                        instanceMap->GetMaxPlayers(),
-                                        instanceDifficulty,
+                                    chatHandle.PSendSysMessage("There are %u player(s) in this instance. Difficulty is set to %u player(s).|r",
                                         mapABInfo->playerCount,
                                         mapABInfo->adjustedPlayerCount
                                     );
@@ -4649,7 +4651,7 @@ class AutoBalance_AllMapScript : public AllMapScript
                                     // notify GMs that they won't be accounted for
                                     if (player->IsGameMaster())
                                     {
-                                        chatHandle.PSendSysMessage("|cffc3dbff [AutoBalance]|r|cffFF8000 Your GM flag is turned on. AutoBalance will ignore you. Please turn GM off and exit/re-enter the instance if you'd like to be considering for AutoBalancing.|r");
+                                        chatHandle.PSendSysMessage("Your GM flag is turned on. AutoBalance will ignore you. Please turn GM off and exit/re-enter the instance if you'd like to be considering for AutoBalancing.|r");
                                     }
                                 }
                                 else
@@ -4657,7 +4659,7 @@ class AutoBalance_AllMapScript : public AllMapScript
                                     // announce non-GMs entering the instance only
                                     if (!player->IsGameMaster())
                                     {
-                                        chatHandle.PSendSysMessage("|cffc3dbff [AutoBalance]|r|cffFF8000 %s enters the instance. There are %u player(s) in this instance. Difficulty set to %u player(s).|r",
+                                        chatHandle.PSendSysMessage("%s enters the instance. There are %u player(s) in this instance. Difficulty is set to %u player(s).|r",
                                             player->GetName().c_str(),
                                             mapABInfo->playerCount,
                                             mapABInfo->adjustedPlayerCount
@@ -4770,14 +4772,14 @@ class AutoBalance_AllMapScript : public AllMapScript
 
                                 if (mapABInfo->combatLocked)
                                 {
-                                    chatHandle.PSendSysMessage("|cffc3dbff [AutoBalance]|r|cffFF8000 %s left the instance while combat was in progress. Difficulty locked to no less than %u players until combat ends.|r",
+                                    chatHandle.PSendSysMessage("%s left the instance while combat was in progress. Difficulty locked to no less than %u players until combat ends.|r",
                                         player->GetName().c_str(),
                                         mapABInfo->adjustedPlayerCount
                                     );
                                 }
                                 else
                                 {
-                                    chatHandle.PSendSysMessage("|cffc3dbff [AutoBalance]|r|cffFF8000 %s left the instance. There are %u player(s) in this instance. Difficulty set to %u player(s).|r",
+                                    chatHandle.PSendSysMessage("%s left the instance. There are %u player(s) in this instance. Difficulty is set to %u player(s).|r",
                                         player->GetName().c_str(),
                                         mapABInfo->playerCount,
                                         mapABInfo->adjustedPlayerCount
@@ -6439,48 +6441,66 @@ public:
     {
         static std::vector<ChatCommand> ABCommandTable =
         {
-            { "setoffset",        SEC_GAMEMASTER,                        true, &HandleABSetOffsetCommand,                 "Sets the global Player Difficulty Offset for instances. Example: (You + offset(1) = 2 player difficulty)." },
-            { "getoffset",        SEC_PLAYER,                            true, &HandleABGetOffsetCommand,                 "Shows current global player offset value." },
-            { "mapstat",          SEC_PLAYER,                            true, &HandleABMapStatsCommand,                  "Shows current autobalance information for this map" },
-            { "creaturestat",     SEC_PLAYER,                            true, &HandleABCreatureStatsCommand,             "Shows current autobalance information for selected creature." },
+            { "setplayers",        SEC_PLAYER,                            true, &HandleABPlayerOffsetCommand,              "Sets a fixed difficulty of the map bassed on the number of passed players." },
+            { "getmapstat",        SEC_PLAYER,                            true, &HandleABMapStatsCommand,                  "Shows current autobalance information for this map" },
+            { "getcreaturestat",   SEC_PLAYER,                            true, &HandleABCreatureStatsCommand,             "Shows current autobalance information for selected creature." },
         };
 
         static std::vector<ChatCommand> commandTable =
         {
-            { "autobalance",     SEC_PLAYER,                             false, NULL,                      "", ABCommandTable },
-            { "ab",              SEC_PLAYER,                             false, NULL,                      "", ABCommandTable },
+            { "dungeonscale",       SEC_PLAYER,                             false, NULL,                      "", ABCommandTable },
         };
         return commandTable;
     }
 
-    static bool HandleABSetOffsetCommand(ChatHandler* handler, const char* args)
+    static bool HandleABPlayerOffsetCommand(ChatHandler* handler, const char* args)
     {
         if (!*args)
         {
-            handler->PSendSysMessage(".autobalance setoffset #");
-            handler->PSendSysMessage("Sets the Player Difficulty Offset for instances. Example: (You + offset(1) = 2 player difficulty).");
+            handler->PSendSysMessage(".dungeon players #");
+            handler->PSendSysMessage("Sets the locked Player Difficulty for the current instance, or 0 or -1 to clear.  Example: '.dungeon players 2' = 2 player difficulty.");
             return false;
         }
-        char* offset = strtok((char*)args, " ");
-        int32 offseti = -1;
 
+        Player* player = handler->GetPlayer();
+        if (player->GetMap()->IsDungeon() == false)
+        {
+            handler->PSendSysMessage("This command can only be used in a dungeon or raid.");
+            return false;
+        }
+
+        char* offset = strtok((char*)args, " ");
+        int32 newOffset = 0;
         if (offset)
         {
-            offseti = (uint32)atoi(offset);
-            handler->PSendSysMessage("Changing Player Difficulty Offset to %i.", offseti);
-            PlayerCountDifficultyOffset = offseti;
-            globalConfigTime = GetCurrentConfigTime();
+            newOffset = (int32)atoi(offset);
+            if (newOffset == -1 || newOffset == 0)
+            {
+                handler->PSendSysMessage("Clearing Locked Player Difficulty for the current dungeon instance...", newOffset);
+                newOffset = 0;
+            }
+            else if (newOffset > player->GetMap()->ToInstanceMap()->GetMaxPlayers())
+            {
+                handler->PSendSysMessage("Passed number of players is higher than the map max players, so setting to %u", player->GetMap()->ToInstanceMap()->GetMaxPlayers());
+                handler->PSendSysMessage("Locking Player Difficulty to %i for the current dungeon instance, even if players join or leave...", newOffset);
+                newOffset = player->GetMap()->ToInstanceMap()->GetMaxPlayers();
+            }
+            else
+            {
+                handler->PSendSysMessage("Locking Player Difficulty to %i for the current dungeon instance, even if players join or leave...", newOffset);
+            }
+
+            AutoBalanceMapInfo* mapABInfo = player->GetMap()->CustomData.GetDefault<AutoBalanceMapInfo>("AutoBalanceMapInfo");
+            mapABInfo->overridePlayerCount = newOffset;
+            mapABInfo->globalConfigTime = mapABInfo->globalConfigTime - 1;
+
             return true;
         }
         else
-            handler->PSendSysMessage("Error changing Player Difficulty Offset! Please try again.");
-        return false;
-    }
-
-    static bool HandleABGetOffsetCommand(ChatHandler* handler, const char* /*args*/)
-    {
-        handler->PSendSysMessage("Current Player Difficulty Offset = %i", PlayerCountDifficultyOffset);
-        return true;
+        {
+            handler->PSendSysMessage("Error changing Player Difficulty! (Was a number of players provided?)");
+            return false;
+        }
     }
 
     static bool HandleABMapStatsCommand(ChatHandler* handler, const char* /*args*/)

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -3588,7 +3588,7 @@ class AutoBalance_PlayerScript : public PlayerScript
                     {
                         // Ensure that the players always get the same money, even when entering the dungeon alone
                         auto maxPlayerCount = map->ToInstanceMap()->GetMaxPlayers();
-                        auto currentPlayerCount = mapABInfo->playerCount;
+                        auto currentPlayerCount = mapABInfo->adjustedPlayerCount;
                         LOG_DEBUG("module.AutoBalance", "AutoBalance_PlayerScript::OnBeforeLootMoney: Distributing money from '{}' in fixed mode - {}->{}",
                                  sourceCreature->GetName(), loot->gold, uint32(loot->gold * creatureABInfo->MoneyModifier * ((float)currentPlayerCount / maxPlayerCount)));
                         loot->gold = uint32(loot->gold * creatureABInfo->MoneyModifier * ((float)currentPlayerCount / maxPlayerCount));
@@ -3598,7 +3598,7 @@ class AutoBalance_PlayerScript : public PlayerScript
                 else
                 {
                     auto maxPlayerCount = map->ToInstanceMap()->GetMaxPlayers();
-                    auto currentPlayerCount = mapABInfo->playerCount;
+                    auto currentPlayerCount = mapABInfo->adjustedPlayerCount;
                     LOG_DEBUG("module.AutoBalance", "AutoBalance_PlayerScript::OnBeforeLootMoney: Distributing money from a non-creature in fixed mode - {}->{}",
                              loot->gold, uint32(loot->gold * ((float)currentPlayerCount / maxPlayerCount)));
                     loot->gold = uint32(loot->gold * ((float)currentPlayerCount / maxPlayerCount));
@@ -4647,7 +4647,7 @@ class AutoBalance_AllMapScript : public AllMapScript
 
                                 if (thisPlayer && thisPlayer == player) // This is the player that entered
                                 {
-                                    chatHandle.PSendSysMessage("There are %u player(s) in this instance. Difficulty is set to %u player(s).|r Use '.dungeon players' to adjust.",
+                                    chatHandle.PSendSysMessage("There are %u player(s) in this instance. Difficulty is set to %u player(s).|r Use '.dungeon setplayers' to adjust.",
                                         mapABInfo->playerCount,
                                         mapABInfo->adjustedPlayerCount
                                     );
@@ -4663,7 +4663,7 @@ class AutoBalance_AllMapScript : public AllMapScript
                                     // announce non-GMs entering the instance only
                                     if (!player->IsGameMaster())
                                     {
-                                        chatHandle.PSendSysMessage("%s enters the instance. There are %u player(s) in this instance. Difficulty is set to %u player(s).|r  Use '.dungeon players' to adjust.",
+                                        chatHandle.PSendSysMessage("%s enters the instance. There are %u player(s) in this instance. Difficulty is set to %u player(s).|r  Use '.dungeon setplayers' to adjust.",
                                             player->GetName().c_str(),
                                             mapABInfo->playerCount,
                                             mapABInfo->adjustedPlayerCount
@@ -4783,7 +4783,7 @@ class AutoBalance_AllMapScript : public AllMapScript
                                 }
                                 else
                                 {
-                                    chatHandle.PSendSysMessage("%s left the instance. There are %u player(s) in this instance. Difficulty is set to %u player(s).|r  Use '.dungeon players' to adjust.",
+                                    chatHandle.PSendSysMessage("%s left the instance. There are %u player(s) in this instance. Difficulty is set to %u player(s).|r  Use '.dungeon setplayers' to adjust.",
                                         player->GetName().c_str(),
                                         mapABInfo->playerCount,
                                         mapABInfo->adjustedPlayerCount

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -6486,12 +6486,12 @@ public:
             else if (newOffset > player->GetMap()->ToInstanceMap()->GetMaxPlayers())
             {
                 handler->PSendSysMessage("Passed number of players is higher than the map max players, so setting to %u", player->GetMap()->ToInstanceMap()->GetMaxPlayers());
-                handler->PSendSysMessage("Locking Player Difficulty to %i for the current dungeon instance, even if players join or leave...", newOffset);
                 newOffset = player->GetMap()->ToInstanceMap()->GetMaxPlayers();
+                handler->PSendSysMessage("Locking Player Difficulty to %i for the current dungeon instance.", newOffset);
             }
             else
             {
-                handler->PSendSysMessage("Locking Player Difficulty to %i for the current dungeon instance, even if players join or leave...", newOffset);
+                handler->PSendSysMessage("Locking Player Difficulty to %i for the current dungeon instance.", newOffset);
             }
 
             AutoBalanceMapInfo* mapABInfo = player->GetMap()->CustomData.GetDefault<AutoBalanceMapInfo>("AutoBalanceMapInfo");

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -6594,7 +6594,6 @@ public:
                                     mapABInfo->activeCreatureCount,
                                     mapABInfo->allMapCreatures.size()
                                     );
-
             return true;
         }
         else


### PR DESCRIPTION
- Give ability for player to adjust number of players in a dungeon directly
- Added loop drop chance control, tied to players
- Change the commands to use .dungeonscale, as well as other properties for preference
- Removed GM command to set all dungeon scale in-game
- Corrected a long-standing bug that wasn't factoring for adjusted player count in money scale
- Update wiki to match